### PR TITLE
[Feature-009-recruitment-2] 채용공고 삭제 기능 구현

### DIFF
--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/applying/ApplyingController.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/applying/ApplyingController.java
@@ -1,7 +1,7 @@
 package com.internship.wanted.wantedpreonboardingbackend.application.controller.applying;
 
 
-import com.internship.wanted.wantedpreonboardingbackend.application.usecase.ApplyingToRecruitmentUsercase;
+import com.internship.wanted.wantedpreonboardingbackend.application.usecase.ApplyingToRecruitmentUsecase;
 import com.internship.wanted.wantedpreonboardingbackend.application.usecase.GetApplyingUserUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/applying")
 public class ApplyingController {
 
-	private final ApplyingToRecruitmentUsercase applyingToRecruitmentUsercase;
+	private final ApplyingToRecruitmentUsecase applyingToRecruitmentUsecase;
 	private final GetApplyingUserUsecase getApplyingUserUsecase;
 
 	@PostMapping("/{toRecruitmentId}/{fromUserId}")
 	public ResponseEntity<?> applying(@PathVariable Long toRecruitmentId,
 		@PathVariable Long fromUserId) {
 		return ResponseEntity.ok()
-			.body(applyingToRecruitmentUsercase.execute(toRecruitmentId, fromUserId));
+			.body(applyingToRecruitmentUsecase.execute(toRecruitmentId, fromUserId));
 	}
 
 	@GetMapping("/users/{fromRecruitmentId}")

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/recruitment/RecruitmentController.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/recruitment/RecruitmentController.java
@@ -1,5 +1,6 @@
 package com.internship.wanted.wantedpreonboardingbackend.application.controller.recruitment;
 
+import com.internship.wanted.wantedpreonboardingbackend.application.usecase.DeleteRecruitmentUsecase;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.RecruitmentForm;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.service.RecruitmentReadService;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.service.RecruitmentWriteService;
@@ -21,6 +22,7 @@ public class RecruitmentController {
 
 	private final RecruitmentWriteService recruitmentWriteService;
 	private final RecruitmentReadService recruitmentReadService;
+	private final DeleteRecruitmentUsecase deleteRecruitmentUsecase;
 
 	@PostMapping("/registration")
 	public ResponseEntity<?> registration(@RequestBody RecruitmentForm.Request request) {
@@ -41,7 +43,7 @@ public class RecruitmentController {
 
 	@DeleteMapping("/delete/{recruitmentId}")
 	public ResponseEntity<?> deleteRecruitment(@PathVariable Long recruitmentId) {
-		recruitmentWriteService.deleteRecruitment(recruitmentId);
+		deleteRecruitmentUsecase.execute(recruitmentId);
 		return ResponseEntity.ok().body(true);
 	}
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/ApplyingToRecruitmentUsecase.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/ApplyingToRecruitmentUsecase.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ApplyingToRecruitmentUsercase {
+public class ApplyingToRecruitmentUsecase {
 
 	private final UserReadService userReadService;
 	private final RecruitmentReadService recruitmentReadService;

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/DeleteRecruitmentUsecase.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/DeleteRecruitmentUsecase.java
@@ -1,0 +1,19 @@
+package com.internship.wanted.wantedpreonboardingbackend.application.usecase;
+
+import com.internship.wanted.wantedpreonboardingbackend.domain.apply.service.ApplyingWriteService;
+import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.service.RecruitmentWriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DeleteRecruitmentUsecase {
+
+	private final RecruitmentWriteService recruitmentWriteService;
+	private final ApplyingWriteService applyingWriteService;
+
+	public void execute(Long toRecruitmentId) {
+		recruitmentWriteService.deleteRecruitment(toRecruitmentId);
+		applyingWriteService.deleteApplying(toRecruitmentId);
+	}
+}

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/repository/ApplyingRepository.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/repository/ApplyingRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ApplyingRepository extends JpaRepository<Applying, Long> {
 	Optional<Applying> findByToRecruitmentIdAndFromUserId(Long companyId, Long userId);
 	List<Applying> findAllByToRecruitmentId(Long toRecruitmentId);
+	void deleteAllByToRecruitmentId(Long toRecruitmentId);
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/service/ApplyingWriteService.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/service/ApplyingWriteService.java
@@ -25,7 +25,9 @@ public class ApplyingWriteService {
 				.fromUserId(userId)
 				.build()));
 	}
-
+	public void deleteApplying(Long recruitmentId) {
+		applyingRepository.deleteAllByToRecruitmentId(recruitmentId);
+	}
 	private void validApplying(Long recruitmentId, Long userId) {
 		if (applyingRepository.findByToRecruitmentIdAndFromUserId(recruitmentId, userId).isPresent()) {
 			throw new RuntimeException("공고 하나에 한번만 지원할 수 있습니다.");


### PR DESCRIPTION
## Change

- 채용공고를 삭제할 수 있다.
  - url path = /recruitments/delete/{recruitmentId}
  - 채용공고가 삭제되면 해당 공고에 지원했던 유저 데이터도 사라진다.

## Trouble

- 지원내용을 database에 영원히 저장할 필요가 있을까 고민해봐야겠다.