### PR TITLE
[Feature-011-recruitment-3] 채용공고 모아보기, 삭제하기 기능 구현

### DIFF
--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/applying/ApplyingController.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/applying/ApplyingController.java
@@ -19,17 +19,17 @@ public class ApplyingController {
 	private final ApplyingToRecruitmentUsecase applyingToRecruitmentUsecase;
 	private final GetApplyingUserUsecase getApplyingUserUsecase;
 
-	@PostMapping("/{toRecruitmentId}/{fromUserId}")
-	public ResponseEntity<?> applying(@PathVariable Long toRecruitmentId,
-		@PathVariable Long fromUserId) {
+	@PostMapping("/{recruitmentId}/{userId}")
+	public ResponseEntity<?> applying(@PathVariable Long recruitmentId,
+		@PathVariable Long userId) {
 		return ResponseEntity.ok()
-			.body(applyingToRecruitmentUsecase.execute(toRecruitmentId, fromUserId));
+			.body(applyingToRecruitmentUsecase.execute(recruitmentId, userId));
 	}
 
-	@GetMapping("/users/{fromRecruitmentId}")
-	public ResponseEntity<?> getApplyingUserList(@PathVariable Long fromRecruitmentId) {
+	@GetMapping("/users/{recruitmentId}")
+	public ResponseEntity<?> getApplyingUserList(@PathVariable Long recruitmentId) {
 		return ResponseEntity.ok()
-			.body(getApplyingUserUsecase.execute(fromRecruitmentId));
+			.body(getApplyingUserUsecase.execute(recruitmentId));
 	}
 
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/recruitment/RecruitmentController.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/controller/recruitment/RecruitmentController.java
@@ -4,6 +4,7 @@ import com.internship.wanted.wantedpreonboardingbackend.application.usecase.Dele
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.RecruitmentForm;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.service.RecruitmentReadService;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.service.RecruitmentWriteService;
+import javax.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,5 +47,10 @@ public class RecruitmentController {
 	public ResponseEntity<?> deleteRecruitment(@PathVariable Long recruitmentId) {
 		deleteRecruitmentUsecase.execute(recruitmentId);
 		return ResponseEntity.ok().body(true);
+	}
+
+	@GetMapping("/page=?")
+	public ResponseEntity<?> getRecruitments(@RequestParam @Min(1) Long num) {
+		return ResponseEntity.ok().body(recruitmentReadService.getRecruitments(num));
 	}
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/DeleteRecruitmentUsecase.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/application/usecase/DeleteRecruitmentUsecase.java
@@ -12,8 +12,8 @@ public class DeleteRecruitmentUsecase {
 	private final RecruitmentWriteService recruitmentWriteService;
 	private final ApplyingWriteService applyingWriteService;
 
-	public void execute(Long toRecruitmentId) {
-		recruitmentWriteService.deleteRecruitment(toRecruitmentId);
-		applyingWriteService.deleteApplying(toRecruitmentId);
+	public void execute(Long recruitmentId) {
+		recruitmentWriteService.deleteRecruitment(recruitmentId);
+		applyingWriteService.deleteApplying(recruitmentId);
 	}
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/service/ApplyingWriteService.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/apply/service/ApplyingWriteService.java
@@ -7,6 +7,7 @@ import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.R
 import com.internship.wanted.wantedpreonboardingbackend.domain.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,9 +26,12 @@ public class ApplyingWriteService {
 				.userId(userId)
 				.build()));
 	}
+
+	@Transactional
 	public void deleteApplying(Long recruitmentId) {
 		applyingRepository.deleteAllByRecruitmentId(recruitmentId);
 	}
+
 	private void validApplying(Long recruitmentId, Long userId) {
 		if (applyingRepository.findByRecruitmentIdAndUserId(recruitmentId, userId).isPresent()) {
 			throw new RuntimeException("공고 하나에 한번만 지원할 수 있습니다.");

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/dto/RecruitmentForm.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/dto/RecruitmentForm.java
@@ -33,7 +33,6 @@ public class RecruitmentForm {
 		private String country;
 		private String position;
 		private Long compensation;
-		private String contents;
 		private String skill;
 		private LocalDate deadline;
 
@@ -46,7 +45,6 @@ public class RecruitmentForm {
 				.country(entity.getCountry())
 				.companyName(entity.getCompanyName())
 				.position(entity.getPosition())
-				.contents(entity.getContents())
 				.skill(entity.getSkill())
 				.deadline(entity.getDeadline())
 				.build();

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/repositoty/RecruitmentRepository.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/repositoty/RecruitmentRepository.java
@@ -3,11 +3,13 @@ package com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.repo
 import com.internship.wanted.wantedpreonboardingbackend.domain.company.entity.Company;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.entity.Recruitment;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
-
 	List<Recruitment> findAllByCompany(Company company);
+	Page<Recruitment> findAll(Pageable pageable);
 }

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/service/RecruitmentReadService.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/service/RecruitmentReadService.java
@@ -2,10 +2,14 @@ package com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.serv
 
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.RecruitmentDetail;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.RecruitmentDto;
+import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.dto.RecruitmentForm;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.entity.Recruitment;
 import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.repositoty.RecruitmentRepository;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,6 +32,13 @@ public class RecruitmentReadService {
 		);
 
 		return recruitmentDetail;
+	}
+
+	public List<RecruitmentForm.Response> getRecruitments(Long num) {
+		int pageNum = num.intValue();
+		Pageable limit = PageRequest.of(pageNum, pageNum * 10);
+		return recruitmentRepository.findAll(limit)
+			.map(RecruitmentForm.Response::fromEntity).toList();
 	}
 
 	public RecruitmentDto getRecruitment(Long recruitmentId) {

--- a/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/service/RecruitmentWriteService.java
+++ b/src/main/java/com/internship/wanted/wantedpreonboardingbackend/domain/recruitment/service/RecruitmentWriteService.java
@@ -8,6 +8,7 @@ import com.internship.wanted.wantedpreonboardingbackend.domain.recruitment.repos
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +44,7 @@ public class RecruitmentWriteService {
 		return RecruitmentForm.Response.fromEntity(recruitment);
 	}
 
+	@Transactional
 	public RecruitmentForm.Response updateRecruitmentDetail(
 		Long recruitmentId,
 		RecruitmentForm.Request request) {
@@ -58,6 +60,7 @@ public class RecruitmentWriteService {
 			.fromEntity(recruitmentRepository.save(recruitment));
 	}
 
+	@Transactional(readOnly = true)
 	public void deleteRecruitment(Long recruitmentId) {
 		Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
 			.orElseThrow(() -> new RuntimeException("공고를 찾을 수 없습니다."));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,4 +16,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    open-in-view: false
 


### PR DESCRIPTION
## Change

- 공고 삭제 
  - 공고가 삭제됐어도 지원한 유저 data가 삭제되지 않는 문제 해결
    - JPA Transaction 연산 로직에 @Transactional 사용

- 공고 모아보기
  - 전체 공고중 JPA Repository에서 Page를 이용해 data반환
    - url path : /recruitments/page=?
    - param = pageNum
    - page limit = pageNum ~ pageNum * 10
